### PR TITLE
Auto-Resolve JDK distribution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 include("common")
 include("fabric")
 include("neoforge")


### PR DESCRIPTION
Adds a plugin to the Gradle's settings file that allows JDK toolchain to be auto-resolved.