### PR TITLE
fix: handle blank tooltip translations

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
@@ -321,8 +321,9 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
     private static Component translatableTooltip(Identifier identifier, String category) {
         String key = identifier.toLanguageKey("options.".concat(category)).concat(".tooltip");
         Component translatable = Component.translatable(key);
+        String tooltip = translatable.getString().replaceAll("§.", "");
 
-        if (!ComponentUtils.isTranslationResolvable(translatable)) {
+        if (!ComponentUtils.isTranslationResolvable(translatable) || tooltip.isBlank()) {
             translatable = Component.translatable(
                     "sodium-extra.option.".concat(category).concat(".tooltips"),
                     translatableName(identifier, category)


### PR DESCRIPTION
## Summary

* Treat resolved tooltip translations that render as blank as invalid.
* Fall back to the existing generic tooltip translation instead.

## Why

Resource packs can define a translation key with an empty or whitespace-only value. `ComponentUtils.isTranslationResolvable` still returns `true` in this case, so Sodium Extra can pass a blank component to Sodium's config API, which rejects it with:

```text
IllegalArgumentException: Tooltip must not be blank
```

This is a follow-up to [#532](https://github.com/FlashyReese/sodium-extra/issues/532) and [#534](https://github.com/FlashyReese/sodium-extra/issues/534). The earlier fix added fallback handling for blank option names, but the same validation is not currently applied to registry-backed tooltip translations.

For example, the issue can be reproduced with a resource pack containing:

```json
{
  "options.particles.minecraft.ominous_spawning.tooltip": ""
}
```

When this translation is resolved, `translatableTooltip()` returns the blank component instead of using the existing generic particle-tooltip fallback.

This change treats blank tooltip translations the same as unresolved translations and falls back to the existing generic tooltip.

The same code path is also present on `1.21.11/dev` and may benefit from a backport.

## Validation

* Successfully ran the full Gradle build with Temurin 25.0.4.
* Fabric and NeoForge artifacts were generated successfully.
* Reproduced the crash with a resource pack containing a blank particle tooltip.
* Confirmed that the same resource pack no longer causes config registration to fail after the fix.

The implementation was prepared with assistance from Codex, and I manually verified the fix using the validation steps above.