### PR TITLE
FEAT: Display aspect ratio in fullscreen res option

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
@@ -1,6 +1,7 @@
 package me.flashyreese.mods.sodiumextra.common.util;
 
 import com.mojang.blaze3d.platform.Monitor;
+import com.mojang.blaze3d.platform.VideoMode;
 import me.flashyreese.mods.sodiumextra.client.fog.FogDistanceHelper;
 import net.caffeinemc.mods.sodium.api.config.option.ControlValueFormatter;
 import net.minecraft.client.Minecraft;
@@ -14,9 +15,22 @@ public interface ControlValueFormatterExtended extends ControlValueFormatter {
                 return Component.translatable("options.fullscreen.unavailable");
             } else {
                 int modeIndex = Math.clamp(v - 1, 0, monitor.modeCount() - 1);
-                return v == 0 ? Component.translatable("options.fullscreen.current") : Component.literal(monitor.mode(modeIndex).toString().replace(" (24bit)", ""));
+                if (v == 0) {
+                    return Component.translatable("options.fullscreen.current");
+                }
+                VideoMode mode = monitor.mode(modeIndex);
+                int w = mode.getWidth();
+                int h = mode.getHeight();
+                int g = gcd(w, h);
+                String ratio = (w / g) + ":" + (h / g);
+                String formatted = w + "x" + h + "@" + mode.getRefreshRate() + " (" + ratio + " | " + mode.getBitsPerPixel() + "bit)";
+                return Component.literal(formatted);
             }
         };
+    }
+
+    private static int gcd(int a, int b) {
+        return b == 0 ? a : gcd(b, a % b);
     }
 
     static ControlValueFormatter fogDistance() {

--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
@@ -30,7 +30,12 @@ public interface ControlValueFormatterExtended extends ControlValueFormatter {
     }
 
     private static int gcd(int a, int b) {
-        return b == 0 ? a : gcd(b, a % b);
+        while (b != 0) {
+            int remainder = a % b;
+            a = b;
+            b = remainder;
+        }
+        return a;
     }
 
     static ControlValueFormatter fogDistance() {


### PR DESCRIPTION
Adds the aspect ratio to the fullscreen resolution label

```
Before: 1600x900@60 (24bit)
After:  1600x900@60 (16:9 | 24bit)
```

The ratio is computed via GCD, so uncommon resolutions like 1280x1024 show correctly as 5:4 rather than a guess.

NOTE! The original code stripped bit depth entirely via `.replace(" (24bit)", "")`.
This change builds the string manually from VideoMode's getters, which
brings bit depth back, happy to drop it if that was intentional