### PR TITLE
Use EYE_PLANE_ABSOLUTE_NV calculation instead for planar fog distance

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/client/fog/FogShaderTransformer.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/client/fog/FogShaderTransformer.java
@@ -69,7 +69,7 @@ public final class FogShaderTransformer {
             """.formatted(Float.toString(FogDistanceHelper.CYLINDRICAL_VERTICAL_SCALE));
 
     private static final String VERTEX_PLANAR_DECL = "\nout float v_PlanarDistance;";
-    private static final String VERTEX_PLANAR_COMPUTE = "v_PlanarDistance = -(u_ModelViewMatrix * vec4(position, 1.0)).z;\n\n    ";
+    private static final String VERTEX_PLANAR_COMPUTE = "v_PlanarDistance = abs((u_ModelViewMatrix * vec4(position, 1.0)).z);\n\n    ";
     private static final String VERTEX_CYLINDRICAL_DECL = "\nout vec2 v_SodiumExtraCylindricalDistance;";
     private static final String VERTEX_CYLINDRICAL_COMPUTE = "v_SodiumExtraCylindricalDistance = vec2(length(position.xz), abs(position.y));\n    ";
     private static final String FRAGMENT_PLANAR_DECL = "\nin float v_PlanarDistance;";


### PR DESCRIPTION
It was the most common among Nvidia GPUs which used Planar Fog Distance.

EYE_PLANE_ABSOLUTE_NV: This takes the absolute value of the eye-coordinate depth. It acts as a safety barrier against rendering bugs when objects pass behind the camera plane, preventing math inversions where fog calculation metrics might overflow or clip incorrectly.